### PR TITLE
fix plugin collection state not being reset properly in testsuite

### DIFF
--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -79,6 +79,7 @@ trait ConsoleIntegrationTestTrait
      */
     public function exec(string $command, array $input = []): void
     {
+        $this->clearPlugins();
         $runner = $this->makeRunner();
 
         $this->_out ??= new StubConsoleOutput();

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -491,6 +491,7 @@ trait IntegrationTestTrait
      */
     protected function _sendRequest(array|string $url, string $method, array|string $data = []): void
     {
+        $this->clearPlugins();
         $dispatcher = $this->_makeDispatcher();
         $url = $dispatcher->resolveUrl($url);
 

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite;
 
 use Cake\Core\HttpApplicationInterface;
+use Cake\Core\Plugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\FlashMessage;
 use Cake\Http\Server;
@@ -91,6 +92,7 @@ class MiddlewareDispatcher
 
         $out = Router::url($url);
         Router::resetRoutes();
+        Plugin::getCollection()->clear();
 
         return $out;
     }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -227,6 +227,7 @@ abstract class TestCase extends BaseTestCase
             Configure::write($this->_configure);
         }
         $this->getTableLocator()->clear();
+        $this->clearPlugins();
         $this->_configure = [];
         $this->_tableLocator = null;
         if (class_exists(Mockery::class)) {
@@ -364,6 +365,7 @@ abstract class TestCase extends BaseTestCase
     public function clearPlugins(): void
     {
         Plugin::getCollection()->clear();
+        Configure::delete('plugins');
     }
 
     /**

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -76,7 +76,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testSymlink(): void
     {
-        $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
+        Configure::write('Plugins.autoload', ['TestPlugin' => ['routes' => false], 'Company/TestPluginThree' => []]);
 
         $this->exec('plugin assets symlink');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
@@ -92,7 +92,7 @@ class PluginAssetsCommandsTest extends TestCase
 
     public function testSymlinkWhenVendorDirectoryExists(): void
     {
-        $this->loadPlugins(['Company/TestPluginThree']);
+        Configure::write('Plugins.autoload', ['Company/TestPluginThree' => []]);
 
         mkdir($this->wwwRoot . 'company');
 
@@ -109,7 +109,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testSymlinkWhenTargetAlreadyExits(): void
     {
-        $this->loadPlugins(['TestTheme']);
+        Configure::write('Plugins.autoload', ['TestTheme' => []]);
 
         $output = new StubConsoleOutput();
         $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
@@ -134,7 +134,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testForPluginWithoutWebroot(): void
     {
-        $this->loadPlugins(['TestPluginTwo']);
+        Configure::write('Plugins.autoload', ['TestPluginTwo' => []]);
 
         $this->exec('plugin assets symlink');
         $this->assertFileDoesNotExist($this->wwwRoot . 'test_plugin_two');
@@ -145,7 +145,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testSymlinkingSpecifiedPlugin(): void
     {
-        $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
+        Configure::write('Plugins.autoload', ['TestPlugin' => ['routes' => false], 'Company/TestPluginThree' => []]);
 
         $this->exec('plugin assets symlink TestPlugin');
 
@@ -162,7 +162,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testCopy(): void
     {
-        $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
+        Configure::write('Plugins.autoload', ['TestPlugin' => ['routes' => false], 'Company/TestPluginThree' => []]);
 
         $this->exec('plugin assets copy');
 
@@ -180,7 +180,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testCopyOverwrite(): void
     {
-        $this->loadPlugins(['TestPlugin' => ['routes' => false]]);
+        Configure::write('Plugins.autoload', ['TestPlugin' => ['routes' => false]]);
 
         $this->exec('plugin assets copy');
 
@@ -207,7 +207,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testRemoveSymlink(): void
     {
-        $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
+        Configure::write('Plugins.autoload', ['TestPlugin' => ['routes' => false], 'Company/TestPluginThree' => []]);
 
         mkdir($this->wwwRoot . 'company');
 
@@ -230,7 +230,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testRemoveFolder(): void
     {
-        $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
+        Configure::write('Plugins.autoload', ['TestPlugin' => ['routes' => false], 'Company/TestPluginThree' => []]);
 
         $this->exec('plugin assets copy');
 
@@ -250,7 +250,7 @@ class PluginAssetsCommandsTest extends TestCase
      */
     public function testOverwrite(): void
     {
-        $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
+        Configure::write('Plugins.autoload', ['TestPlugin' => ['routes' => false], 'Company/TestPluginThree' => []]);
 
         $path = $this->wwwRoot . 'test_plugin';
 

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -18,9 +18,7 @@ namespace Cake\Test\TestCase\Console\Command;
 
 use Cake\Console\CommandInterface;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
-use Cake\Core\Plugin;
-use Cake\Http\BaseApplication;
-use Cake\Http\MiddlewareQueue;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -37,16 +35,7 @@ class HelpCommandTest extends TestCase
     {
         parent::setUp();
         $this->setAppNamespace();
-        Plugin::getCollection()->clear();
-
-        $app = new class ('') extends BaseApplication
-        {
-            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
-            {
-                return $middlewareQueue;
-            }
-        };
-        $app->addPlugin('TestPlugin');
+        Configure::write('Plugins.autoload', ['TestPlugin', 'TestPluginTwo']);
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -267,6 +267,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->clearPlugins();
 
         $this->configApplication(Configure::read('App.namespace') . '\ApplicationWithPluginRoutes', null);
+        Configure::write('Plugins.autoload', ['TestPlugin', 'TestPluginTwo']);
 
         $this->get('/test_plugin');
         $this->assertResponseOk();

--- a/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace TestApp;
 
+use Cake\Core\Configure;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Middleware\RoutingMiddleware;
@@ -37,7 +38,12 @@ class ApplicationWithDefaultRoutes extends BaseApplication
      */
     public function bootstrap(): void
     {
-        // Do nothing.
+        // Only load plugins defined in Configure.
+        if (Configure::check('Plugins.autoload')) {
+            foreach (Configure::read('Plugins.autoload') as $name => $options) {
+                $this->addPlugin($name, $options);
+            }
+        }
     }
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue

--- a/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace TestApp;
 
+use Cake\Core\Configure;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Middleware\RoutingMiddleware;
@@ -26,7 +27,13 @@ class ApplicationWithPluginRoutes extends BaseApplication
     public function bootstrap(): void
     {
         parent::bootstrap();
-        $this->addPlugin('TestPlugin');
+
+        // Load plugins defined in Configure.
+        if (Configure::check('Plugins.autoload')) {
+            foreach (Configure::read('Plugins.autoload') as $value) {
+                $this->addPlugin($value);
+            }
+        }
     }
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue


### PR DESCRIPTION
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
